### PR TITLE
Correct Python 3 syntax errors with Python 2.6-compatible syntax.

### DIFF
--- a/aspen/auth/httpdigest.py
+++ b/aspen/auth/httpdigest.py
@@ -133,8 +133,8 @@ class Storage(dict):
     def __getattr__(self, key):
         try:
             return self[key]
-        except KeyError, k:
-            raise AttributeError, k
+        except KeyError as k:
+            raise AttributeError(k)
 
     def __setattr__(self, key, value):
         self[key] = value
@@ -142,8 +142,8 @@ class Storage(dict):
     def __delattr__(self, key):
         try:
             del self[key]
-        except KeyError, k:
-            raise AttributeError, k
+        except KeyError as k:
+            raise AttributeError(k)
 
     def __repr__(self):
         return '<Storage ' + dict.__repr__(self) + '>'

--- a/aspen/configuration/__init__.py
+++ b/aspen/configuration/__init__.py
@@ -74,10 +74,10 @@ class Configurable(object):
             if isinstance(value, str):
                 value = raw.decode('US-ASCII')
             hydrated = from_unicode(value)
-        except UnicodeDecodeError, error:
+        except UnicodeDecodeError as error:
             value = ascii_dammit(value)
             error_detail = "Configuration values must be US-ASCII."
-        except ValueError, error:
+        except ValueError as error:
             error_detail = error.args[0]
 
         if error is not None:
@@ -166,7 +166,7 @@ class Configurable(object):
                 # facility.
 
                 return os.getcwd()
-            except OSError, err:
+            except OSError as err:
                 if err.errno != errno.ENOENT:
                     raise
                 raise ConfigurationError(errorstr)

--- a/aspen/simplates/__init__.py
+++ b/aspen/simplates/__init__.py
@@ -226,7 +226,7 @@ class Simplate(object):
         context.update(self.defaults.initial_context)
 
         one = compile(one.padded_content, self.fs, 'exec')
-        exec one in context    # mutate context
+        exec(one, context)    # mutate context
         one = context          # store it
 
         two = compile(two.padded_content, self.fs, 'exec')


### PR DESCRIPTION
Yet another small step toward Python 3 compatibility with no impairment for Python 2.